### PR TITLE
Fix initial indexing for large photo libraries

### DIFF
--- a/Sources/CairnCore/CairnSettings.swift
+++ b/Sources/CairnCore/CairnSettings.swift
@@ -169,6 +169,30 @@ public struct CairnSettings: Sendable, Codable, Equatable {
     /// device).
     public var timeDisplayFormat: TimeDisplayFormat
 
+    /// How many assets the foreground initial-scan hash pipeline will
+    /// run concurrently. Drives the `TaskGroup` ceiling in
+    /// `PhotoKitPersistentChangeReconciler.hashAssets` — higher values
+    /// saturate iCloud bandwidth on network-bound libraries and win
+    /// some NAND parallelism on local libraries, but raise peak memory
+    /// (Live Photo videos / ProRes clips reserve tens of MB each during
+    /// the fetch). Default 4 is the conservative value previous builds
+    /// hardcoded; advanced users can raise it for faster initial scans
+    /// on devices with headroom, or lower it on memory-pressed older
+    /// hardware.
+    ///
+    /// Changes take effect on the next sync — the reconciler reads this
+    /// at construction time, not per-batch, so changing it mid-scan
+    /// doesn't retroactively widen the active TaskGroup.
+    public var hashConcurrency: Int
+
+    /// Permitted range for `hashConcurrency`. `1` opts out of parallelism
+    /// entirely (useful for diagnosing thermal / memory issues by
+    /// comparing serial vs parallel timing). `16` is the practical
+    /// ceiling — beyond that, PhotoKit's per-asset overhead and
+    /// SwiftData write serialization dominate and the next added task
+    /// produces diminishing returns. UI clamps on write.
+    public static let hashConcurrencyRange: ClosedRange<Int> = 1...16
+
     /// Opt-in switch for the incremental server-side sync path
     /// (`POST /api/sync/stream` change-data-capture instead of the
     /// paginated `search/metadata` rescan). Default **off** during
@@ -295,6 +319,7 @@ public struct CairnSettings: Sendable, Codable, Equatable {
         indexingScope: IndexingScope = .fullLibrary,
         maxRetryAttempts: Int = 5,
         timeDisplayFormat: TimeDisplayFormat = .system,
+        hashConcurrency: Int = 4,
         useIncrementalServerSync: Bool = false,
         fastInitialScan: Bool = false,
         propagationMaxAgeDays: Int? = nil,
@@ -316,6 +341,7 @@ public struct CairnSettings: Sendable, Codable, Equatable {
         self.indexingScope = indexingScope
         self.maxRetryAttempts = maxRetryAttempts
         self.timeDisplayFormat = timeDisplayFormat
+        self.hashConcurrency = hashConcurrency
         self.useIncrementalServerSync = useIncrementalServerSync
         self.fastInitialScan = fastInitialScan
         self.propagationMaxAgeDays = propagationMaxAgeDays
@@ -339,6 +365,7 @@ public struct CairnSettings: Sendable, Codable, Equatable {
         case indexingScope
         case maxRetryAttempts
         case timeDisplayFormat
+        case hashConcurrency
         case useIncrementalServerSync
         case fastInitialScan
         case propagationMaxAgeDays
@@ -364,6 +391,7 @@ public struct CairnSettings: Sendable, Codable, Equatable {
         self.indexingScope = try c.decodeIfPresent(IndexingScope.self, forKey: .indexingScope) ?? d.indexingScope
         self.maxRetryAttempts = try c.decodeIfPresent(Int.self, forKey: .maxRetryAttempts) ?? d.maxRetryAttempts
         self.timeDisplayFormat = try c.decodeIfPresent(TimeDisplayFormat.self, forKey: .timeDisplayFormat) ?? d.timeDisplayFormat
+        self.hashConcurrency = try c.decodeIfPresent(Int.self, forKey: .hashConcurrency) ?? d.hashConcurrency
         self.useIncrementalServerSync = try c.decodeIfPresent(Bool.self, forKey: .useIncrementalServerSync) ?? d.useIncrementalServerSync
         self.fastInitialScan = try c.decodeIfPresent(Bool.self, forKey: .fastInitialScan) ?? d.fastInitialScan
         self.propagationMaxAgeDays = try c.decodeIfPresent(Int.self, forKey: .propagationMaxAgeDays) ?? d.propagationMaxAgeDays

--- a/Sources/CairnIOSCore/PhotoKitPersistentChangeReconciler.swift
+++ b/Sources/CairnIOSCore/PhotoKitPersistentChangeReconciler.swift
@@ -242,8 +242,10 @@ public final class PhotoKitPersistentChangeReconciler {
     ///   - Lower caps peak memory (a parallel ProRes video can reserve
     ///     tens of MB each) and leaves more headroom for iOS BG slots.
     /// 4 empirically balances throughput and memory pressure on modern
-    /// iPhones. Profile before moving it.
-    private let maxConcurrentHashes: Int = 4
+    /// iPhones. Threaded through from `CairnSettings.hashConcurrency`
+    /// so advanced users can tune it via Settings → Advanced; tests
+    /// and the CLI keep the legacy default by omitting the parameter.
+    private let maxConcurrentHashes: Int
 
     /// Per-asset iCloud-download soft limit, in bytes. Summed across
     /// unavailable resources (Live Photos contribute both still and
@@ -418,6 +420,7 @@ public final class PhotoKitPersistentChangeReconciler {
         requireExplicitDeletionEvent: Bool = false,
         scope: IndexingScope = .fullLibrary,
         propagationMaxAgeDays: @escaping @Sendable () -> Int? = { nil },
+        maxConcurrentHashes: Int = 4,
         onHashProgress: @escaping @Sendable (Int, Int, Set<Checksum>) async -> Void = { _, _, _ in },
         onPhaseChange: @escaping @Sendable (String, Int) async -> Void = { _, _ in },
         onHashStarted: @escaping @Sendable (String, String, Int64) async -> Void = { _, _, _ in },
@@ -440,6 +443,7 @@ public final class PhotoKitPersistentChangeReconciler {
         self.requireExplicitDeletionEvent = requireExplicitDeletionEvent
         self.scope = scope
         self.propagationMaxAgeDays = propagationMaxAgeDays
+        self.maxConcurrentHashes = max(1, maxConcurrentHashes)
         self.onHashProgress = onHashProgress
         self.onPhaseChange = onPhaseChange
         self.onHashStarted = onHashStarted

--- a/Sources/CairnIOSCore/PhotoKitPersistentChangeReconciler.swift
+++ b/Sources/CairnIOSCore/PhotoKitPersistentChangeReconciler.swift
@@ -1969,7 +1969,14 @@ public final class PhotoKitPersistentChangeReconciler {
         let startedAt = Date()
         let now = clock()
         let log = Self.reconLog
-        let entries: [LocalAssetMetadata] = try await Task.detached(priority: .userInitiated) {
+        //
+        // Cancellation contract: `Task.detached` does NOT inherit parent
+        // cancellation, so we forward it manually via
+        // `withTaskCancellationHandler`. Without this, a Stop-indexing
+        // tap unwinds the orchestrator immediately (UI flips to Paused)
+        // while this loop keeps grinding on a background thread, printing
+        // PhotoKit warnings for minutes after the user thinks they stopped.
+        let work = Task.detached(priority: .userInitiated) {
             var entries: [LocalAssetMetadata] = []
             entries.reserveCapacity(pending.count)
             for (index, asset) in pending.enumerated() {
@@ -2014,7 +2021,12 @@ public final class PhotoKitPersistentChangeReconciler {
                 ))
             }
             return entries
-        }.value
+        }
+        let entries = try await withTaskCancellationHandler {
+            try await work.value
+        } onCancel: {
+            work.cancel()
+        }
         try await metadataStore.record(entries)
         let totalElapsed = Int(Date().timeIntervalSince(startedAt) * 1000)
         Self.reconLog.notice("[cairn.recon.metadata] complete: \(totalPending, privacy: .public) entries recorded in \(totalElapsed, privacy: .public)ms")
@@ -2057,14 +2069,23 @@ public final class PhotoKitPersistentChangeReconciler {
             let currentDates: [String: Date]
             let currentSizes: [String: Int64]
         }
-        let enumResult: EnumResult = await Task.detached(priority: .userInitiated) {
+        let work = Task.detached(priority: .userInitiated) {
             var entries: [LocalAssetMetadata] = []
             var currentDates: [String: Date] = [:]
             var currentSizes: [String: Int64] = [:]
             entries.reserveCapacity(fetch.count)
             currentDates.reserveCapacity(fetch.count)
             currentSizes.reserveCapacity(fetch.count)
-            fetch.enumerateObjects { asset, _, _ in
+            fetch.enumerateObjects { asset, idx, stop in
+                // Honor cancellation forwarded from the parent task via
+                // the surrounding `withTaskCancellationHandler`. The
+                // detached task's own cancel flag flips when the parent
+                // signals; we bail out of the synchronous enumeration by
+                // tripping PhotoKit's `stop` pointer.
+                if Task.isCancelled {
+                    stop.pointee = true
+                    return
+                }
                 let resources = PHAssetResource.assetResources(for: asset)
                 let primary = PhotoKitPhotoEnumerator.selectPrimaryResource(from: resources)
                 let size = primary.flatMap(PhotoKitPhotoEnumerator.resourceFileSize)
@@ -2089,7 +2110,17 @@ public final class PhotoKitPersistentChangeReconciler {
                 }
             }
             return EnumResult(entries: entries, currentDates: currentDates, currentSizes: currentSizes)
-        }.value
+        }
+        // Forward parent cancellation into the detached task. `Task.detached`
+        // does not inherit cancellation, so without this a cancelled outer
+        // task would still wait for the full enumeration to drain before
+        // unwinding (and the UI would appear stuck in a stopping-but-busy
+        // state).
+        let enumResult: EnumResult = await withTaskCancellationHandler {
+            await work.value
+        } onCancel: {
+            work.cancel()
+        }
         let entries = enumResult.entries
         let currentDates = enumResult.currentDates
         let currentSizes = enumResult.currentSizes

--- a/Sources/CairnIOSCore/PhotoKitPersistentChangeReconciler.swift
+++ b/Sources/CairnIOSCore/PhotoKitPersistentChangeReconciler.swift
@@ -1954,53 +1954,67 @@ public final class PhotoKitPersistentChangeReconciler {
             return
         }
 
+        // The per-asset PhotoKit reads below (`PHAssetResource.assetResources`,
+        // `originalFilename`, `creationDate`, `modificationDate`) are ~10ms
+        // each on real devices and, on iOS 26, fault
+        // `PHAssetOriginalMetadataProperties` synchronously on the main queue
+        // when the asset wasn't prefetched. Even though this method's caller
+        // is `async` and nominally cooperative, inheriting the caller's
+        // executor can land us on a queue that competes with the UI runloop.
+        // A detached background task gives PhotoKit's main-queue faults room
+        // to interleave with UI redraws, so the InitialScanScreen progress
+        // bar can actually animate while we churn through 100k+ assets.
         let totalPending = pending.count
         Self.reconLog.notice("[cairn.recon.metadata] starting: \(totalPending, privacy: .public) PHAssetResource calls pending — full-enum hashing waits for this to complete")
         let startedAt = Date()
         let now = clock()
-        var entries: [LocalAssetMetadata] = []
-        entries.reserveCapacity(pending.count)
-        for (index, asset) in pending.enumerated() {
-            // Cooperate with cancellation. `PHAssetResource.assetResources(for:)`
-            // is ~10ms per call on a real device, so a fresh-install enum
-            // of 7k assets blocks here for ~70s. Without this check, a
-            // user tap on Stop indexing would have to wait the full pass
-            // out before the orchestrator unwinds. Check every 50
-            // iterations — checkCancellation is cheap but we don't need
-            // to pay it on every tick.
-            if index % 50 == 0 {
-                try Task.checkCancellation()
+        let log = Self.reconLog
+        let entries: [LocalAssetMetadata] = try await Task.detached(priority: .userInitiated) {
+            var entries: [LocalAssetMetadata] = []
+            entries.reserveCapacity(pending.count)
+            for (index, asset) in pending.enumerated() {
+                // Cooperate with cancellation. `PHAssetResource.assetResources(for:)`
+                // is ~10ms per call on a real device, so a fresh-install enum
+                // of 7k assets blocks here for ~70s. Without this check, a
+                // user tap on Stop indexing would have to wait the full pass
+                // out before the orchestrator unwinds. Check every 50
+                // iterations — checkCancellation is cheap but we don't need
+                // to pay it on every tick.
+                if index % 50 == 0 {
+                    try Task.checkCancellation()
+                }
+                // Periodic heartbeat in the logs so a 100k+-asset library
+                // that hits this path (imputation off, fresh install)
+                // doesn't look frozen for an hour. End-user diagnostic
+                // exports were silent through this whole loop before, even
+                // though the loop was making steady progress.
+                if index > 0 && index % 5000 == 0 {
+                    let elapsed = Date().timeIntervalSince(startedAt)
+                    let rate = Double(index) / max(elapsed, 0.001)
+                    let etaSeconds = Double(totalPending - index) / max(rate, 0.001)
+                    log.notice("[cairn.recon.metadata] progress: \(index, privacy: .public)/\(totalPending, privacy: .public) — \(Int(rate * 1000), privacy: .public)/s × 1000, eta=\(Int(etaSeconds), privacy: .public)s")
+                }
+                let resources = PHAssetResource.assetResources(for: asset)
+                let primary = PhotoKitPhotoEnumerator.selectPrimaryResource(from: resources)
+                let size = primary.flatMap(PhotoKitPhotoEnumerator.resourceFileSize)
+                entries.append(LocalAssetMetadata(
+                    localIdentifier: asset.localIdentifier,
+                    originalFileName: primary?.originalFilename,
+                    creationDate: asset.creationDate,
+                    modificationDate: asset.modificationDate,
+                    fileSize: size,
+                    observedAt: now,
+                    // Capture every resource filename, not just the primary —
+                    // edited assets carry the pre-edit upload name (e.g.
+                    // `IMG_2999.MOV`) only in a non-primary resource, and the
+                    // alive-on-phone safety check needs it. Omitting this was
+                    // silently erasing the build-121 protection on every
+                    // full-enum metadata write.
+                    allResourceFilenames: resources.map(\.originalFilename).filter { !$0.isEmpty }
+                ))
             }
-            // Periodic heartbeat in the logs so a 100k+-asset library
-            // that hits this path (imputation off, fresh install)
-            // doesn't look frozen for an hour. End-user diagnostic
-            // exports were silent through this whole loop before, even
-            // though the loop was making steady progress.
-            if index > 0 && index % 5000 == 0 {
-                let elapsed = Date().timeIntervalSince(startedAt)
-                let rate = Double(index) / max(elapsed, 0.001)
-                let etaSeconds = Double(totalPending - index) / max(rate, 0.001)
-                Self.reconLog.notice("[cairn.recon.metadata] progress: \(index, privacy: .public)/\(totalPending, privacy: .public) — \(Int(rate * 1000), privacy: .public)/s × 1000, eta=\(Int(etaSeconds), privacy: .public)s")
-            }
-            let resources = PHAssetResource.assetResources(for: asset)
-            let primary = PhotoKitPhotoEnumerator.selectPrimaryResource(from: resources)
-            let size = primary.flatMap(PhotoKitPhotoEnumerator.resourceFileSize)
-            entries.append(LocalAssetMetadata(
-                localIdentifier: asset.localIdentifier,
-                originalFileName: primary?.originalFilename,
-                creationDate: asset.creationDate,
-                modificationDate: asset.modificationDate,
-                fileSize: size,
-                observedAt: now,
-                // Capture every resource filename, not just the primary —
-                // edited assets carry the pre-edit upload name (e.g.
-                // `IMG_2999.MOV`) only in a non-primary resource, and the
-                // alive-on-phone safety check needs it. Omitting this was
-                // silently erasing the build-121 protection on every
-                // full-enum metadata write.
-                allResourceFilenames: resources.map(\.originalFilename).filter { !$0.isEmpty }
-            ))
-        }
+            return entries
+        }.value
         try await metadataStore.record(entries)
         let totalElapsed = Int(Date().timeIntervalSince(startedAt) * 1000)
         Self.reconLog.notice("[cairn.recon.metadata] complete: \(totalPending, privacy: .public) entries recorded in \(totalElapsed, privacy: .public)ms")
@@ -2032,36 +2046,53 @@ public final class PhotoKitPersistentChangeReconciler {
         guard !allIds.isEmpty else { return ObservationResult(staleUpdates: []) }
         let fetch = PHAsset.fetchAssets(withLocalIdentifiers: Array(allIds), options: nil)
         let now = clock()
-        var entries: [LocalAssetMetadata] = []
-        var currentDates: [String: Date] = [:]
-        var currentSizes: [String: Int64] = [:]
-        entries.reserveCapacity(fetch.count)
-        currentDates.reserveCapacity(fetch.count)
-        currentSizes.reserveCapacity(fetch.count)
-        fetch.enumerateObjects { asset, _, _ in
-            let resources = PHAssetResource.assetResources(for: asset)
-            let primary = PhotoKitPhotoEnumerator.selectPrimaryResource(from: resources)
-            let size = primary.flatMap(PhotoKitPhotoEnumerator.resourceFileSize)
-            entries.append(LocalAssetMetadata(
-                localIdentifier: asset.localIdentifier,
-                originalFileName: primary?.originalFilename,
-                creationDate: asset.creationDate,
-                modificationDate: asset.modificationDate,
-                fileSize: size,
-                observedAt: now,
-                // See `recordFullEnumerationMetadata` — an incremental
-                // insert/update event (including the edit event itself)
-                // must carry every resource filename, or it erases the
-                // pre-edit upload name the alive-on-phone check relies on.
-                allResourceFilenames: resources.map(\.originalFilename).filter { !$0.isEmpty }
-            ))
-            if let date = asset.modificationDate {
-                currentDates[asset.localIdentifier] = date
-            }
-            if let size {
-                currentSizes[asset.localIdentifier] = size
-            }
+        // Push the PHAssetResource + originalFilename reads off our own
+        // executor — same reasoning as `recordFullEnumerationMetadata`.
+        // PhotoKit faults `PHAssetOriginalMetadataProperties` synchronously
+        // on the main queue per asset, so running the enumeration on a
+        // detached task at least leaves room for the UI runloop between
+        // those faults instead of stacking with our own cooperative hop.
+        struct EnumResult: Sendable {
+            let entries: [LocalAssetMetadata]
+            let currentDates: [String: Date]
+            let currentSizes: [String: Int64]
         }
+        let enumResult: EnumResult = await Task.detached(priority: .userInitiated) {
+            var entries: [LocalAssetMetadata] = []
+            var currentDates: [String: Date] = [:]
+            var currentSizes: [String: Int64] = [:]
+            entries.reserveCapacity(fetch.count)
+            currentDates.reserveCapacity(fetch.count)
+            currentSizes.reserveCapacity(fetch.count)
+            fetch.enumerateObjects { asset, _, _ in
+                let resources = PHAssetResource.assetResources(for: asset)
+                let primary = PhotoKitPhotoEnumerator.selectPrimaryResource(from: resources)
+                let size = primary.flatMap(PhotoKitPhotoEnumerator.resourceFileSize)
+                entries.append(LocalAssetMetadata(
+                    localIdentifier: asset.localIdentifier,
+                    originalFileName: primary?.originalFilename,
+                    creationDate: asset.creationDate,
+                    modificationDate: asset.modificationDate,
+                    fileSize: size,
+                    observedAt: now,
+                    // See `recordFullEnumerationMetadata` — an incremental
+                    // insert/update event (including the edit event itself)
+                    // must carry every resource filename, or it erases the
+                    // pre-edit upload name the alive-on-phone check relies on.
+                    allResourceFilenames: resources.map(\.originalFilename).filter { !$0.isEmpty }
+                ))
+                if let date = asset.modificationDate {
+                    currentDates[asset.localIdentifier] = date
+                }
+                if let size {
+                    currentSizes[asset.localIdentifier] = size
+                }
+            }
+            return EnumResult(entries: entries, currentDates: currentDates, currentSizes: currentSizes)
+        }.value
+        let entries = enumResult.entries
+        let currentDates = enumResult.currentDates
+        let currentSizes = enumResult.currentSizes
         // Snapshot cached metadata BEFORE writing the fresh observations
         // — otherwise the size we read back is the one we just wrote, and
         // the content-stability check below collapses to a tautology.

--- a/Sources/CairnIOSCore/UI/SettingsScreen.swift
+++ b/Sources/CairnIOSCore/UI/SettingsScreen.swift
@@ -924,66 +924,13 @@ public struct SettingsScreen: View {
     private var safetyLimitsPage: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 0) {
-                safetyRailsCoreSection
+                safetyRailsSection
                 safetyAlertsSection
             }
         }
         .background(t.bg)
         .navigationTitle("Safety & limits")
         .cairnNavigationTitleDisplayMode(.inline)
-    }
-
-    /// Just the actual safety rails — percent threshold, strictness,
-    /// quarantine, iCloud limits, hard ceiling, propagation cutoff,
-    /// retry attempts. Excluded assets / deferred queue / rescan /
-    /// clear-hash-cache live on Library and Recovery now.
-    private var safetyRailsCoreSection: some View {
-        Group {
-            KeylineSection("Safety rails", icon: "shield", iconTint: t.verified)
-            CairnCard {
-                VStack(spacing: 0) {
-                    VStack(alignment: .leading, spacing: 0) {
-                        HStack(alignment: .firstTextBaseline, spacing: 0) {
-                            Spacer(minLength: 0)
-                            HelpPopover {
-                                Text("**Safety rail.** If a single run would move more than this fraction of matched photos to Immich's Trash, the run aborts without touching the server.")
-                                Text("Defends against bugs, permission regressions, or a library-wipe cascading into a mass delete.")
-                                Text("The \"Count floor\" under Advanced is paired with this: for small libraries, 1% can be just one or two photos, which is noise — the floor sets a minimum batch size before the percent check engages.")
-                            }
-                            .padding(.trailing, 6)
-                        }
-                        .padding(.top, 10)
-                        .padding(.bottom, -4)
-
-                        SliderInputRow(
-                            label: "Percent threshold",
-                            sub: String(
-                                format: "Abort if a run would move more than %.1f%% of matched assets to Immich's Trash.",
-                                settings.maxDeletePercent
-                            ),
-                            value: $settings.maxDeletePercent,
-                            range: 0.5...5,
-                            step: 0.1,
-                            unitSuffix: "%",
-                            format: { String(format: "%.1f", $0) },
-                            parse: NumericInputParse.decimal
-                        )
-                    }
-                    RowDivider()
-                    StrictnessRow(strictness: $settings.deletionStrictness)
-                    RowDivider()
-                    QuarantineRow(days: $settings.quarantineDays)
-                    RowDivider()
-                    ICloudDownloadLimitRow(mb: $settings.iCloudDownloadLimitMB)
-                    RowDivider()
-                    HardCeilingRow(mb: $settings.iCloudMaxEverBytesMB)
-                    RowDivider()
-                    PropagationMaxAgeRow(days: $settings.propagationMaxAgeDays)
-                    RowDivider()
-                    MaxRetryAttemptsRow(attempts: $settings.maxRetryAttempts)
-                }
-            }
-        }
     }
 
     @ViewBuilder
@@ -1130,6 +1077,91 @@ public struct SettingsScreen: View {
                             value: { Text("Enables incremental sync").foregroundStyle(t.textMuted) },
                             chevron: true,
                             onTap: onOpenSessionSignIn
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    // MARK: - Safety rails
+
+    private var safetyRailsSection: some View {
+        Group {
+            KeylineSection("Safety rails", icon: "shield", iconTint: t.verified)
+            CairnCard {
+                // Split the outer VStack into two halves. SwiftUI's
+                // @ViewBuilder accepts up to 17 children in one tuple,
+                // but on iOS 26 the resulting AttributeGraph chain
+                // multiplies preference-resolution depth far enough to
+                // blow the main-thread stack (EXC_BAD_ACCESS in
+                // `___chkstk_darwin`) the first time the section
+                // renders. Splitting into two inner stacks of ≤8
+                // children keeps the layout identical (both stacks use
+                // `spacing: 0`, no padding between) while shrinking
+                // each TupleView's preference fanout enough to fit.
+                VStack(spacing: 0) {
+                    VStack(spacing: 0) {
+                        VStack(alignment: .leading, spacing: 0) {
+                            HStack(alignment: .firstTextBaseline, spacing: 0) {
+                                Spacer(minLength: 0)
+                                HelpPopover {
+                                    Text("**Safety rail.** If a single run would move more than this fraction of matched photos to Immich's Trash, the run aborts without touching the server.")
+                                    Text("Defends against bugs, permission regressions, or a library-wipe cascading into a mass delete.")
+                                    Text("The \"Count floor\" below is paired with this: for small libraries, 1% can be just one or two photos, which is noise — the floor sets a minimum batch size before the percent check engages.")
+                                }
+                                .padding(.trailing, 6)
+                            }
+                            .padding(.top, 10)
+                            .padding(.bottom, -4)
+
+                            SliderInputRow(
+                                label: "Percent threshold",
+                                sub: String(
+                                    format: "Abort if a run would move more than %.1f%% of matched assets to Immich's Trash.",
+                                    settings.maxDeletePercent
+                                ),
+                                value: $settings.maxDeletePercent,
+                                range: 0.5...5,
+                                step: 0.1,
+                                unitSuffix: "%",
+                                format: { String(format: "%.1f", $0) },
+                                parse: NumericInputParse.decimal
+                            )
+                        }
+                        RowDivider()
+                        StrictnessRow(strictness: $settings.deletionStrictness)
+                        RowDivider()
+                        QuarantineRow(days: $settings.quarantineDays)
+                        RowDivider()
+                        ICloudDownloadLimitRow(mb: $settings.iCloudDownloadLimitMB)
+                    }
+                    VStack(spacing: 0) {
+                        RowDivider()
+                        HardCeilingRow(mb: $settings.iCloudMaxEverBytesMB)
+                        RowDivider()
+                        PropagationMaxAgeRow(days: $settings.propagationMaxAgeDays)
+                        RowDivider()
+                        MaxRetryAttemptsRow(attempts: $settings.maxRetryAttempts)
+                        RowDivider()
+                        DeferredQueueRow(
+                            summary: deferredQueue,
+                            isSyncing: isSyncing,
+                            syncProgress: syncProgress,
+                            onHashNow: onForceDrainDeferred
+                        )
+                        RowDivider()
+                        KeyValRow(
+                            "Rescan library",
+                            value: { Text("Force re-enumerate").foregroundStyle(t.infoInk) },
+                            chevron: true,
+                            onTap: { pendingRescanLibrary = true }
+                        )
+                        RowDivider()
+                        KeyValRow(
+                            "Excluded assets",
+                            value: { excludedValue },
+                            onTap: onOpenExcluded
                         )
                     }
                 }

--- a/Sources/CairnIOSCore/UI/SettingsScreen.swift
+++ b/Sources/CairnIOSCore/UI/SettingsScreen.swift
@@ -1090,83 +1090,100 @@ public struct SettingsScreen: View {
         Group {
             KeylineSection("Safety rails", icon: "shield", iconTint: t.verified)
             CairnCard {
-                // Split the outer VStack into two halves. SwiftUI's
-                // @ViewBuilder accepts up to 17 children in one tuple,
-                // but on iOS 26 the resulting AttributeGraph chain
-                // multiplies preference-resolution depth far enough to
-                // blow the main-thread stack (EXC_BAD_ACCESS in
-                // `___chkstk_darwin`) the first time the section
-                // renders. Splitting into two inner stacks of ≤8
-                // children keeps the layout identical (both stacks use
-                // `spacing: 0`, no padding between) while shrinking
-                // each TupleView's preference fanout enough to fit.
+                // The 17-row safety-rails card materializes a deeply
+                // nested `VStack<TupleView<…>>` type at runtime. On iOS
+                // 26 the Swift runtime's mangled-name type decoder
+                // recurses through every generic argument when
+                // instantiating concrete metadata for the closure, and
+                // the depth blows the main-thread stack
+                // (`EXC_BAD_ACCESS` in
+                // `swift::Demangle::TypeDecoder::decodeMangledType`).
+                // Splitting the tuple wasn't enough — the nested
+                // signature was still too deep. Type-erasing each half
+                // via `AnyView` collapses the outer CairnCard content
+                // type to `VStack<TupleView<(AnyView, AnyView)>>`,
+                // which the decoder handles trivially. The runtime
+                // cost is two extra existential boxes — negligible
+                // here, where the card renders once and stays put.
                 VStack(spacing: 0) {
-                    VStack(spacing: 0) {
-                        VStack(alignment: .leading, spacing: 0) {
-                            HStack(alignment: .firstTextBaseline, spacing: 0) {
-                                Spacer(minLength: 0)
-                                HelpPopover {
-                                    Text("**Safety rail.** If a single run would move more than this fraction of matched photos to Immich's Trash, the run aborts without touching the server.")
-                                    Text("Defends against bugs, permission regressions, or a library-wipe cascading into a mass delete.")
-                                    Text("The \"Count floor\" below is paired with this: for small libraries, 1% can be just one or two photos, which is noise — the floor sets a minimum batch size before the percent check engages.")
-                                }
-                                .padding(.trailing, 6)
-                            }
-                            .padding(.top, 10)
-                            .padding(.bottom, -4)
-
-                            SliderInputRow(
-                                label: "Percent threshold",
-                                sub: String(
-                                    format: "Abort if a run would move more than %.1f%% of matched assets to Immich's Trash.",
-                                    settings.maxDeletePercent
-                                ),
-                                value: $settings.maxDeletePercent,
-                                range: 0.5...5,
-                                step: 0.1,
-                                unitSuffix: "%",
-                                format: { String(format: "%.1f", $0) },
-                                parse: NumericInputParse.decimal
-                            )
-                        }
-                        RowDivider()
-                        StrictnessRow(strictness: $settings.deletionStrictness)
-                        RowDivider()
-                        QuarantineRow(days: $settings.quarantineDays)
-                        RowDivider()
-                        ICloudDownloadLimitRow(mb: $settings.iCloudDownloadLimitMB)
-                    }
-                    VStack(spacing: 0) {
-                        RowDivider()
-                        HardCeilingRow(mb: $settings.iCloudMaxEverBytesMB)
-                        RowDivider()
-                        PropagationMaxAgeRow(days: $settings.propagationMaxAgeDays)
-                        RowDivider()
-                        MaxRetryAttemptsRow(attempts: $settings.maxRetryAttempts)
-                        RowDivider()
-                        DeferredQueueRow(
-                            summary: deferredQueue,
-                            isSyncing: isSyncing,
-                            syncProgress: syncProgress,
-                            onHashNow: onForceDrainDeferred
-                        )
-                        RowDivider()
-                        KeyValRow(
-                            "Rescan library",
-                            value: { Text("Force re-enumerate").foregroundStyle(t.infoInk) },
-                            chevron: true,
-                            onTap: { pendingRescanLibrary = true }
-                        )
-                        RowDivider()
-                        KeyValRow(
-                            "Excluded assets",
-                            value: { excludedValue },
-                            onTap: onOpenExcluded
-                        )
-                    }
+                    safetyRailsTop
+                    safetyRailsBottom
                 }
             }
         }
+    }
+
+    private var safetyRailsTop: AnyView {
+        AnyView(
+            VStack(spacing: 0) {
+                VStack(alignment: .leading, spacing: 0) {
+                    HStack(alignment: .firstTextBaseline, spacing: 0) {
+                        Spacer(minLength: 0)
+                        HelpPopover {
+                            Text("**Safety rail.** If a single run would move more than this fraction of matched photos to Immich's Trash, the run aborts without touching the server.")
+                            Text("Defends against bugs, permission regressions, or a library-wipe cascading into a mass delete.")
+                            Text("The \"Count floor\" below is paired with this: for small libraries, 1% can be just one or two photos, which is noise — the floor sets a minimum batch size before the percent check engages.")
+                        }
+                        .padding(.trailing, 6)
+                    }
+                    .padding(.top, 10)
+                    .padding(.bottom, -4)
+
+                    SliderInputRow(
+                        label: "Percent threshold",
+                        sub: String(
+                            format: "Abort if a run would move more than %.1f%% of matched assets to Immich's Trash.",
+                            settings.maxDeletePercent
+                        ),
+                        value: $settings.maxDeletePercent,
+                        range: 0.5...5,
+                        step: 0.1,
+                        unitSuffix: "%",
+                        format: { String(format: "%.1f", $0) },
+                        parse: NumericInputParse.decimal
+                    )
+                }
+                RowDivider()
+                StrictnessRow(strictness: $settings.deletionStrictness)
+                RowDivider()
+                QuarantineRow(days: $settings.quarantineDays)
+                RowDivider()
+                ICloudDownloadLimitRow(mb: $settings.iCloudDownloadLimitMB)
+            }
+        )
+    }
+
+    private var safetyRailsBottom: AnyView {
+        AnyView(
+            VStack(spacing: 0) {
+                RowDivider()
+                HardCeilingRow(mb: $settings.iCloudMaxEverBytesMB)
+                RowDivider()
+                PropagationMaxAgeRow(days: $settings.propagationMaxAgeDays)
+                RowDivider()
+                MaxRetryAttemptsRow(attempts: $settings.maxRetryAttempts)
+                RowDivider()
+                DeferredQueueRow(
+                    summary: deferredQueue,
+                    isSyncing: isSyncing,
+                    syncProgress: syncProgress,
+                    onHashNow: onForceDrainDeferred
+                )
+                RowDivider()
+                KeyValRow(
+                    "Rescan library",
+                    value: { Text("Force re-enumerate").foregroundStyle(t.infoInk) },
+                    chevron: true,
+                    onTap: { pendingRescanLibrary = true }
+                )
+                RowDivider()
+                KeyValRow(
+                    "Excluded assets",
+                    value: { excludedValue },
+                    onTap: onOpenExcluded
+                )
+            }
+        )
     }
 
     // MARK: - Excluded-value sub-view

--- a/Sources/CairnIOSCore/UI/SettingsScreen.swift
+++ b/Sources/CairnIOSCore/UI/SettingsScreen.swift
@@ -1587,6 +1587,8 @@ public struct SettingsScreen: View {
                 VStack(spacing: 0) {
                     CountFloorRow(floor: $settings.minDeleteFloor)
                     RowDivider()
+                    HashConcurrencyRow(value: $settings.hashConcurrency)
+                    RowDivider()
                     ThumbnailCacheCapRow(mb: $settings.thumbnailCacheCapMB)
                     RowDivider()
                     ThumbhashCacheCapRow(mb: $settings.thumbhashCapMB)
@@ -2288,6 +2290,66 @@ private struct CountFloorRow: View {
                 range: 1...50,
                 step: 1,
                 unitSuffix: floor == 1 ? " asset" : " assets",
+                format: { String(format: "%.0f", $0) },
+                parse: NumericInputParse.integer
+            )
+        }
+    }
+}
+
+// MARK: - Hash concurrency row
+
+/// Lets advanced users tune initial-scan parallelism — the `TaskGroup`
+/// ceiling in `PhotoKitPersistentChangeReconciler.hashAssets`. Default
+/// 4 is the previous hardcoded value; users with newer iPhones and
+/// network-bound (iCloud-optimized) libraries can push it higher,
+/// users on older devices can pull it down. Takes effect on the next
+/// sync — the reconciler reads it at construction time.
+private struct HashConcurrencyRow: View {
+    @Binding var value: Int
+    @Environment(\.cairnTokens) private var t
+
+    private var doubleBinding: Binding<Double> {
+        Binding(
+            get: { Double(value) },
+            set: { value = Int($0.rounded()) }
+        )
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            HStack(alignment: .firstTextBaseline, spacing: 0) {
+                Spacer(minLength: 0)
+                HelpPopover {
+                    Text("**Concurrent hashes.** Number of photos the initial scan hashes at the same time. Default 4 is the value previous builds shipped — conservative for older hardware. Modern iPhones (15 Pro, 16, 17) can handle 8–12 comfortably; on an iCloud-heavy library that's where most of the wall-clock win lives, because each parallel slot is doing its own network fetch.")
+
+                    Text("**Trade-offs.**")
+                        .fontWeight(.semibold)
+                        .padding(.top, 2)
+                    Text("• Higher saturates iCloud bandwidth and CPU; faster scans.")
+                    Text("• Higher raises peak memory — a parallel ProRes video or Live Photo motion track can buffer tens of MB during the fetch.")
+                    Text("• Lower reduces memory pressure and leaves more headroom for iOS background slots.")
+                    Text("• `1` opts out of parallelism — useful for comparing serial vs parallel timing when diagnosing a slow scan.")
+
+                    Text("**Rule of thumb.** Start at 4. If the initial scan feels slow and you're on a recent device, try 8. Only push past 12 if you've confirmed memory isn't the bottleneck.")
+                        .padding(.top, 2)
+
+                    Text("**Takes effect on the next sync** — changing this mid-scan doesn't retroactively widen the active task group.")
+                        .padding(.top, 2)
+                        .foregroundStyle(t.textMuted)
+                }
+                .padding(.trailing, 6)
+            }
+            .padding(.top, 10)
+            .padding(.bottom, -4)
+
+            SliderInputRow(
+                label: "Concurrent hashes",
+                sub: "How many photos the initial scan hashes at once. Higher = faster on capable devices; lower = gentler on memory.",
+                value: doubleBinding,
+                range: Double(CairnSettings.hashConcurrencyRange.lowerBound)...Double(CairnSettings.hashConcurrencyRange.upperBound),
+                step: 1,
+                unitSuffix: value == 1 ? " stream" : " streams",
                 format: { String(format: "%.0f", $0) },
                 parse: NumericInputParse.integer
             )

--- a/iOS/App/AppDependencies.swift
+++ b/iOS/App/AppDependencies.swift
@@ -1344,17 +1344,25 @@ final class AppDependencies {
         // hop with PhotoKit's own main-queue dispatch and starves the UI
         // runloop completely. The detached task lets PhotoKit's faults
         // interleave with redraws.
+        //
+        // Cancellation: `Task.detached` does NOT inherit parent
+        // cancellation. Without the `withTaskCancellationHandler` wrap
+        // below, a Stop-indexing tap (or BG expiration) unwinds the
+        // orchestrator immediately while this loop keeps grinding on a
+        // background thread — the UI shows Paused while the reconciler
+        // is still doing work in the console.
         // `fetchAssets(withLocalIdentifiers:)` returns only ids PhotoKit
         // can still resolve, which IS the "intersect with currently-alive"
         // filter — so we no longer run a full-library enumeration plus a
         // per-asset PHAssetResource loop on the main thread.
         let store = self.localAssetMetadataStore
-        await Task.detached(priority: .userInitiated) {
+        let work = Task.detached(priority: .userInitiated) {
             let now = Date()
             let fetch = PHAsset.fetchAssets(withLocalIdentifiers: Array(missingFromMetadata), options: nil)
             var entries: [LocalAssetMetadata] = []
             entries.reserveCapacity(fetch.count)
-            fetch.enumerateObjects { asset, _, _ in
+            fetch.enumerateObjects { asset, _, stop in
+                if Task.isCancelled { stop.pointee = true; return }
                 let resources = PHAssetResource.assetResources(for: asset)
                 let primary = PhotoKitPhotoEnumerator.selectPrimaryResource(from: resources)
                 let size = (primary?.value(forKey: "fileSize") as? NSNumber)?.int64Value
@@ -1368,14 +1376,20 @@ final class AppDependencies {
                     allResourceFilenames: resources.map(\.originalFilename).filter { !$0.isEmpty }
                 ))
             }
-            guard !entries.isEmpty else { return }
-            do {
-                try await store.record(entries)
-                syncLog.notice("[cairn.metadata] backfilled \(entries.count, privacy: .public) entries (cache=\(cacheIdsCount, privacy: .public) had-metadata=\(knownIdsCount, privacy: .public) still-missing=\(missingCount - entries.count, privacy: .public) — those PHAssets are no longer fetchable)")
-            } catch {
-                syncLog.error("[cairn.metadata] backfill failed: \(Self.describeSyncError(error), privacy: .public)")
-            }
-        }.value
+            return entries
+        }
+        let entries: [LocalAssetMetadata] = await withTaskCancellationHandler {
+            await work.value
+        } onCancel: {
+            work.cancel()
+        }
+        guard !entries.isEmpty else { return }
+        do {
+            try await store.record(entries)
+            syncLog.notice("[cairn.metadata] backfilled \(entries.count, privacy: .public) entries (cache=\(cacheIdsCount, privacy: .public) had-metadata=\(knownIdsCount, privacy: .public) still-missing=\(missingCount - entries.count, privacy: .public) — those PHAssets are no longer fetchable)")
+        } catch {
+            syncLog.error("[cairn.metadata] backfill failed: \(Self.describeSyncError(error), privacy: .public)")
+        }
     }
 
     /// Build-121 metadata backfill: for installs already past their

--- a/iOS/App/AppDependencies.swift
+++ b/iOS/App/AppDependencies.swift
@@ -112,6 +112,7 @@ final class AppDependencies {
             requireExplicitDeletionEvent: isLimitedAccess,
             scope: activeScope,
             propagationMaxAgeDays: { propagationCutoff },
+            maxConcurrentHashes: Self.clampHashConcurrency(model.settings.hashConcurrency),
             onHashProgress: { [weak self] done, total, newChecksums in
                 // Fetch all MainActor-isolated state in one hop.
                 struct Snapshot {
@@ -5862,6 +5863,18 @@ final class AppDependencies {
     /// force-unwrap right next to the safety check that justifies it.
     nonisolated fileprivate static func megabytesToBytes(_ mb: Int?) -> Int64? {
         mb.flatMap { $0 > 0 ? Int64($0) * 1024 * 1024 : nil }
+    }
+
+    /// Clamp the user's `hashConcurrency` setting into the supported
+    /// range before passing it to the reconciler. A persisted file from
+    /// a build with a wider range, or a debug-tools poke that wrote an
+    /// out-of-bounds value, can't crash the hash pipeline — the
+    /// reconciler also caps at `max(1, …)` defensively, but applying
+    /// the documented range here keeps "what the user picked" and
+    /// "what got used" within the slider's bounds.
+    nonisolated fileprivate static func clampHashConcurrency(_ raw: Int) -> Int {
+        let range = CairnSettings.hashConcurrencyRange
+        return min(range.upperBound, max(range.lowerBound, raw))
     }
 
     private static func serverContainerURL(for key: ServerPartitionKey) -> URL {

--- a/iOS/App/AppDependencies.swift
+++ b/iOS/App/AppDependencies.swift
@@ -199,6 +199,7 @@ final class AppDependencies {
                     // we can't mark this from the call site; the progress
                     // callback is the natural signal.
                     if self.model.syncPhase == .preparing {
+                        syncLog.notice("[cairn.debug.progress] FIRST hash progress emit done=\(done, privacy: .public) total=\(total, privacy: .public) — flipping .preparing → .hashing")
                         self.model.transitionSyncPhase(to: .hashing)
                     }
                     // Persist a fresh per-asset rate to UserDefaults
@@ -239,6 +240,7 @@ final class AppDependencies {
                 // just closed. Surface them in the activity feed as `.note`
                 // entries so the drill-down sheet shows the granular
                 // progression alongside the high-level phase.
+                syncLog.notice("[cairn.debug.phase] \(phaseName, privacy: .public) · \(elapsedMs, privacy: .public)ms")
                 guard let self else { return }
                 await MainActor.run {
                     self.model.appendSyncActivity(.init(
@@ -248,6 +250,16 @@ final class AppDependencies {
                 }
             },
             onHashStarted: { [weak self] assetID, filename, sizeBytes in
+                // Per-asset console trace. Always log the FIRST few so we
+                // can see hashing actually started; after that, sample
+                // every 200th asset to avoid flooding Console.
+                let count = AppDependencies.debugHashStartedCount.withLock { state -> Int in
+                    state += 1
+                    return state
+                }
+                if count <= 5 || count.isMultiple(of: 200) {
+                    syncLog.notice("[cairn.debug.hashStarted] #\(count, privacy: .public) id=\(assetID, privacy: .public) name=\(filename ?? "?", privacy: .public) size=\(sizeBytes, privacy: .public)b")
+                }
                 guard let self else { return }
                 await MainActor.run {
                     let item = CairnAppModel.HashingItem(
@@ -273,6 +285,10 @@ final class AppDependencies {
             }
         )
     }
+
+    /// Debug-only counter for the `onHashStarted` console trace.
+    /// Lock-protected so cross-actor callbacks can increment safely.
+    nonisolated static let debugHashStartedCount = OSAllocatedUnfairLock(initialState: 0)
 
     nonisolated static let massOffloadRecentWindow: TimeInterval = 24 * 60 * 60
 
@@ -1316,23 +1332,24 @@ final class AppDependencies {
         let knownIds = Set(metadataSnapshot.map(\.localIdentifier))
         let cacheIds = (try? await self.localHashStore.allLocalIdentifiers()) ?? []
         let missingFromMetadata = cacheIds.subtracting(knownIds)
+        let cacheIdsCount = cacheIds.count
+        let knownIdsCount = knownIds.count
+        let missingCount = missingFromMetadata.count
         guard !missingFromMetadata.isEmpty else { return }
 
-        let store = self.localAssetMetadataStore
-        let cacheCount = cacheIds.count
-        let knownCount = knownIds.count
-        let missingCount = missingFromMetadata.count
-
-        // Re-fetch the missing ids and build entries off the MainActor.
+        // Move the PhotoKit enumeration + per-asset PHAssetResource reads
+        // off the main actor. On iOS 26 each `PHAssetResource.assetResources(for:)`
+        // call faults `PHAssetOriginalMetadataProperties` synchronously on
+        // the main queue, so running the loop on MainActor stacks the
+        // hop with PhotoKit's own main-queue dispatch and starves the UI
+        // runloop completely. The detached task lets PhotoKit's faults
+        // interleave with redraws.
         // `fetchAssets(withLocalIdentifiers:)` returns only ids PhotoKit
         // can still resolve, which IS the "intersect with currently-alive"
-        // filter the old code did by enumerating the full visibleFetch —
-        // so we no longer run a full-library enumeration plus a per-asset
-        // PHAssetResource loop on the main thread (near-whole-cache on an
-        // upgrade install whose metadata store predates the piggyback
-        // write). Mirrors migrateResourceFilenamesIfNeeded, which already
-        // detaches. Awaited so it still completes before the sync proceeds.
-        await Task.detached(priority: .utility) {
+        // filter — so we no longer run a full-library enumeration plus a
+        // per-asset PHAssetResource loop on the main thread.
+        let store = self.localAssetMetadataStore
+        await Task.detached(priority: .userInitiated) {
             let now = Date()
             let fetch = PHAsset.fetchAssets(withLocalIdentifiers: Array(missingFromMetadata), options: nil)
             var entries: [LocalAssetMetadata] = []
@@ -1354,7 +1371,7 @@ final class AppDependencies {
             guard !entries.isEmpty else { return }
             do {
                 try await store.record(entries)
-                syncLog.notice("[cairn.metadata] backfilled \(entries.count, privacy: .public) entries (cache=\(cacheCount, privacy: .public) had-metadata=\(knownCount, privacy: .public) still-missing=\(missingCount - entries.count, privacy: .public) — those PHAssets are no longer fetchable)")
+                syncLog.notice("[cairn.metadata] backfilled \(entries.count, privacy: .public) entries (cache=\(cacheIdsCount, privacy: .public) had-metadata=\(knownIdsCount, privacy: .public) still-missing=\(missingCount - entries.count, privacy: .public) — those PHAssets are no longer fetchable)")
             } catch {
                 syncLog.error("[cairn.metadata] backfill failed: \(Self.describeSyncError(error), privacy: .public)")
             }
@@ -1886,8 +1903,12 @@ final class AppDependencies {
         model.resetSyncNarration()
         model.transitionSyncPhase(to: .preparing)
         model.appendSyncActivity(.init(kind: .note, detail: "Sync started"))
+        syncLog.notice("[cairn.debug.recon] performLiveReconciliation ENTRY — phase=.preparing")
+        AppDependencies.debugHashStartedCount.withLock { $0 = 0 }
 
+        let tStats = Date()
         await refreshLibrarySizeStats()
+        syncLog.notice("[cairn.debug.recon] refreshLibrarySizeStats DONE in \(Int(Date().timeIntervalSince(tStats) * 1000), privacy: .public)ms — library.local=\(self.model.library.local, privacy: .public) indexed=\(self.model.library.indexed, privacy: .public)")
 
         // Refresh server count concurrently — don't block the scan.
         // Bootstrap already seeded this value; this just picks up
@@ -2166,8 +2187,10 @@ final class AppDependencies {
         // `onPhaseChange` for forensic detail without disrupting the
         // user-visible CTA.
         let t0 = Date()
+        syncLog.notice("[cairn.debug.recon] runDeletionScan START")
         let scan = try await reconciler.runDeletionScan(skipDrain: true)
-        syncLog.notice("[cairn.sync] scan took \(Int(Date().timeIntervalSince(t0) * 1000))ms (events=\(scan.changeEventsProcessed))")
+        syncLog.notice("[cairn.debug.recon] runDeletionScan RETURNED in \(Int(Date().timeIntervalSince(t0) * 1000), privacy: .public)ms")
+        syncLog.info("[cairn.sync] scan took \(Int(Date().timeIntervalSince(t0) * 1000))ms (events=\(scan.changeEventsProcessed))")
         let burst = scan.newlyConfirmedDeleted.count
         // Surface the propagation-cutoff outcome to the activity feed
         // when any deletions were filtered out. Without this the


### PR DESCRIPTION
## Summary

Photo libraries (>100,000 photos) seem to be stuck with no progress despite waiting a long time. c0260d13302dd944f358e67b59bfbf8cdacd8178 fixes this by moving the PhotoKit metadata loops off the main actor.

Additionally we can now increase concurrency up to 16 to speed up hashing.

## Test plan

Made changes, reviewed it with a large photo library. The Cairn finally makes progress and works as expected.
