### PR TITLE
Replace device-name placeholder with generic "this device"

### DIFF
--- a/Sources/CairnIOSCore/UI/StatusScreen.swift
+++ b/Sources/CairnIOSCore/UI/StatusScreen.swift
@@ -551,7 +551,7 @@ public struct StatusScreen: View {
     private var reconcilingSubhead: AttributedString {
         var s = AttributedString("reconciling ")
         s.foregroundColor = t.textMuted
-        var device = AttributedString("iPhone 15 Pro")
+        var device = AttributedString("this device")
         device.foregroundColor = t.textBody
         var middle = AttributedString(" against ")
         middle.foregroundColor = t.textMuted


### PR DESCRIPTION
## Summary

The status subhead's hardcoded "iPhone 15 Pro" was a prototype leftover. Ideally we'd use the per-device name in Settings/General/About/Name, but it (UIDevice.current.name) is privacy-gated behind a request-only entitlement on iOS 16+, so use a neutral "this device" string instead.


## Test plan

It builds

## Notes for reviewers

n/a